### PR TITLE
Ignore null groupId when restoring default account.

### DIFF
--- a/src/com/android/server/telecom/PhoneAccountRegistrar.java
+++ b/src/com/android/server/telecom/PhoneAccountRegistrar.java
@@ -1532,7 +1532,7 @@ public class PhoneAccountRegistrar {
                         int outerDepth = parser.getDepth();
                         PhoneAccountHandle accountHandle = null;
                         String userSerialNumberString = null;
-                        String groupId = "";
+                        String groupId = null;
                         while (XmlUtils.nextElementWithin(parser, outerDepth)) {
                             if (parser.getName().equals(ACCOUNT_HANDLE)) {
                                 parser.nextTag();
@@ -1557,9 +1557,9 @@ public class PhoneAccountRegistrar {
                                         "Could not parse UserHandle " + userSerialNumberString);
                             }
                         }
-                        if (accountHandle != null && userHandle != null && groupId != null) {
+                        if (accountHandle != null && userHandle != null) {
                             return new DefaultPhoneAccountHandle(userHandle, accountHandle,
-                                    groupId);
+                                    groupId != null ? groupId : "");
                         }
                     }
                     return null;


### PR DESCRIPTION
When restoring accounts in sPhoneAccountXml.readFromXml, the groupId of
the newly created accounts isn't filled (setGroupId isn't called on the
builder) and thus none of the accounts have a group ID assigned. When
then running setUserSelectedOutgoingPhoneAccount(), the used groupId
consequently is empty, thus it doesn't seem correct to mandate it being
non-empty when later restoring it.

Change-Id: I14256616bae62e6689e0d2d4751f41bd90dfcba6